### PR TITLE
Add bs4 to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
             "numpy>=1.13",
             "astropy",
             "matplotlib",
-            "scikit-learn"
+            "scikit-learn",
+            "bs4"
         ]
     )


### PR DESCRIPTION
Seems that bs4 is used by the `zeus2_io.ObsLog() .read_folder("obslogs")` method, so it might be nice to ensure it's installed automatically